### PR TITLE
TSDK-677 Add simple broadcast support.

### DIFF
--- a/daml-topl-broker/src/main/scala/co/topl/broker/Main.scala
+++ b/daml-topl-broker/src/main/scala/co/topl/broker/Main.scala
@@ -59,7 +59,8 @@ object Main extends IOApp with ParameterProcessorModule with BrokerProcessorModu
                   List(
                     processConversationInvitationState(paramConfig, client, evt),
                     processLvlTransferRequest(paramConfig, client, evt),
-                    processLvlTransferUnproved(paramConfig, client, evt)
+                    processLvlTransferUnproved(paramConfig, client, evt),
+                    processLvlTransferProved(paramConfig, client, evt)
                   ).sequence
                 )
             )

--- a/daml-topl-shared/src/main/scala/co/topl/shared/WalletStateAlgebraDAML.scala
+++ b/daml-topl-shared/src/main/scala/co/topl/shared/WalletStateAlgebraDAML.scala
@@ -36,7 +36,6 @@ object WalletStateAlgebraDAML {
           )
         )
         currentInteractionList <- fromPublisher(currentInteractions, 1)(Async[F]).compile.toList.map(_.get(0).get)
-        _ <- info"Vk encoded: ${Encoding.encodeToBase58(signatureProposition.verificationKey.toByteArray)}"
         someCurrentInteraction <- Async[F].delay(
           currentInteractionList.activeContracts
             .stream()


### PR DESCRIPTION
## Purpose

The goal of this PR is to implement broadcast support for DAML for Tetra.

## Approach

We added one processor  `processLvlTransferProved` to broadcast the transactions created and signed by the operator and the dapp app.

## Testing

The testing was done manually, the process is as follows:

- launch a Bifrost node
- launch a daml node ` cd daml-topl-lib && daml start`
- launch the trigger `cd daml-topl-broker-trigger && daml trigger --dar .daml/dist/daml-topl-broker-trigger-0.1.0.dar --trigger-name Broker.Triggers:startBroker --ledger-host localhost --ledger-port 6865 --ledger-user "operator"`
- launch the operator
- launch the dapp application
- use the Navigator to find the address in the `CurrentInteraction` contract of the dapp
- fund the created wallet: use the CLI to send 1000 LVLs from the genesis node to the address of the current interaction contract
- use the `VaulState` contract choice `SendFunds` to transfer the funds to some new address
- Check that the funds arrive

This process is cumbersome but it shows that the broker is able to perform its task. It still needs a lot a polishing and improving but due to change of priorities, it will stay in its current state until we need the DAML functionality back.

## Tickets

* TSDK-677